### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new,:delete]
+  before_action :authenticate_user!, only: [:new,:destroy]
   before_action :set_item, only:[:show,:edit,:update]
   def index
     @items = Item.all.order(created_at: :desc)
@@ -38,9 +38,13 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    if @item.user == current_user
     @item = Item.find(params[:id])
     @item.destroy
-    redirect_to root_path
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new,:destroy]
-  before_action :set_item, only:[:show,:edit,:update]
+  before_action :set_item, only:[:show,:edit,:update,:destroy]
   def index
     @items = Item.all.order(created_at: :desc)
   end
@@ -39,7 +39,6 @@ class ItemsController < ApplicationController
 
   def destroy
     if @item.user == current_user
-    @item = Item.find(params[:id])
     @item.destroy
       redirect_to root_path
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
+  before_action :authenticate_user!, only: [:new,:delete]
   before_action :set_item, only:[:show,:edit,:update]
   def index
     @items = Item.all.order(created_at: :desc)
@@ -19,11 +19,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    
   end
 
   def edit
-    
     if current_user.nil?
       redirect_to new_user_session_path
     else
@@ -32,14 +30,17 @@ class ItemsController < ApplicationController
   end
 
   def update
-    
     if @item.update(item_params)
       redirect_to item_path
     else
       render :edit, status: :unprocessable_entity
     end
+  end
 
-
+  def destroy
+    @item = Item.find(params[:id])
+    @item.destroy
+    redirect_to root_path
   end
 
   private
@@ -47,9 +48,8 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
-  
+
   def item_params
     params.require(:item).permit(:image, :name, :explanation, :price, :category_id, :condition_id, :shipping_fee_burden_id, :shipping_from_id, :days_to_ship_id).merge(user_id: current_user.id)
   end
-  
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
 
     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
     <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>    


### PR DESCRIPTION
#What
商品削除機能の実装
ログイン状態の場合にのみ、自身が出品した商品情報を削除できること。
削除が完了したら、トップページに遷移すること。
コントローラー記述追加、ビューファイル記述追加

#Why
アプリ内必須事項のため


gyazo
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
[https://gyazo.com/53e0be587bc6133244642c6be9a59b45](url)
